### PR TITLE
Add optional tenant_id argument to compose value when generating UUIDv5

### DIFF
--- a/folio_uuid/folio_uuid.py
+++ b/folio_uuid/folio_uuid.py
@@ -10,7 +10,12 @@ class FolioUUID(uuid.UUID):
 
     base_namespace = uuid.UUID("8405ae4d-b315-42e1-918a-d1919900cf3f")
 
-    def __init__(self, okapi_url: str, folio_object_type: FOLIONamespaces, legacy_identifier: str):
+    def __init__(
+            self, okapi_url: str,
+            folio_object_type: FOLIONamespaces,
+            legacy_identifier: str,
+            tenant_id: str = None
+    ):
         """
         Create a deterministic UUID for a FOLIO tenant
 
@@ -22,13 +27,18 @@ class FolioUUID(uuid.UUID):
             Enum helping to avoid collisions within a tenant.
         legacy_identifier : str
             The actual identifier from the legacy system
+        tenant_id : str
+            The tenant ID for the target tenant at okapi_url. Default: None
         """
         if not str(legacy_identifier or "").strip():
             raise ValueError("Legacy Identifier not provided")
         clean_id = self.clean_iii_identifiers(legacy_identifier)
+        value_components = [okapi_url, folio_object_type.name, clean_id]
+        if tenant_id:
+            value_components.insert(1, tenant_id)
         u = uuid.uuid5(
             self.base_namespace,
-            f"{okapi_url}:{folio_object_type.name}:{clean_id}",
+            ":".join(value_components),
         )
         super(FolioUUID, self).__init__(str(u))
 

--- a/folio_uuid/tests/test_folio_uuid.py
+++ b/folio_uuid/tests/test_folio_uuid.py
@@ -162,3 +162,20 @@ def test_deterministic_uuid_srs_namespaces():
         1,
     )
     assert str(deterministic_uuid_2) != str(deterministic_uuid_1)
+
+def test_deterministic_uuid_with_tenant_id():
+    with_tenant_id = FolioUUID(
+        made_up_okapi_url,
+        FOLIONamespaces.instances,
+        "b1234567",
+        "diku"
+    )
+
+    without_tenant_id = FolioUUID(
+        made_up_okapi_url,
+        FOLIONamespaces.instances,
+        "b1234567"
+    )
+    assert str(with_tenant_id) == '053f8903-2be6-5fe4-985c-6fc6f2dbb566'
+    assert str(without_tenant_id) == '27d1e3f0-35a7-53fe-99ff-7bdb492bff49'
+    


### PR DESCRIPTION
Fixes #7 